### PR TITLE
Fix injection of settingsMenu before first hr in body

### DIFF
--- a/js/expand-video.js
+++ b/js/expand-video.js
@@ -219,7 +219,7 @@ function setupVideosIn(element) {
 onready(function(){
     // Insert menu from settings.js
     if (typeof settingsMenu != "undefined" && typeof Options == "undefined")
-      document.body.insertBefore(settingsMenu, document.getElementsByTagName("hr")[0]);
+      document.body.insertBefore(settingsMenu, document.querySelector("body > hr"));
 
     // Setup Javascript events for videos in document now
     setupVideosIn(document);


### PR DESCRIPTION
The old `document.getElementsByTagName("hr")[0])` causes an error with `insertBefore` because it's not a direct child of the `body` element. The first `hr` is actually inside the `<form name="post">` element and it breaks the `insertBefore` because the reference node is expected to be a direct child of the parent element you use `insertBefore` on