### PR TITLE
Prevent quotation when cite id is missing

### DIFF
--- a/templates/main.js
+++ b/templates/main.js
@@ -271,7 +271,7 @@ function dopost(form) {
 function citeReply(id, with_link) {
 	var textarea = document.getElementById('body');
 
-	if (!textarea) return false;
+	if (!id || !textarea) return false;
 	
 	if (document.selection) {
 		// IE


### PR DESCRIPTION
Without a validation of `id` a quote to `>>undefined` is appended to the post.
```js
citeReply();
// or
let someId;
citeReply(someId);
```